### PR TITLE
Allow lightboxID for getImageObject

### DIFF
--- a/src/MadeYourDay/Contao/Element/CustomElement.php
+++ b/src/MadeYourDay/Contao/Element/CustomElement.php
@@ -183,13 +183,14 @@ class CustomElement extends \ContentElement
 	/**
 	 * Get an image object from id/uuid and an optional size configuration
 	 *
-	 * @param  int|string   $id       ID, UUID string or binary
-	 * @param  string|array $size     [width, height, mode] optionally serialized
-	 * @param  int          $maxSize  Gets passed to addImageToTemplate
-	 * @param  bool         $fullsize Gets passed to addImageToTemplate as $arrItem['fullsize']
-	 * @return object                 Image object (similar as addImageToTemplate)
+	 * @param  int|string   $id            ID, UUID string or binary
+	 * @param  string|array $size          [width, height, mode] optionally serialized
+	 * @param  int          $maxSize       Gets passed to addImageToTemplate
+	 * @param string	$strLightboxId Gets passed to addImageToTemplate
+	 * @param  bool         $fullsize      Gets passed to addImageToTemplate as $arrItem['fullsize']
+	 * @return object                      Image object (similar as addImageToTemplate)
 	 */
-	public function getImageObject($id, $size = null, $maxSize = null, $fullsize = null)
+	public function getImageObject($id, $size = null, $maxSize = null, $strLightboxId=null, $fullsize = null)
 	{
 		global $objPage;
 
@@ -245,7 +246,7 @@ class CustomElement extends \ContentElement
 		);
 
 		$imageObject = new \FrontendTemplate('rsce_image_object');
-		$this->addImageToTemplate($imageObject, $image, $maxSize);
+		$this->addImageToTemplate($imageObject, $image, $maxSize, $strLightboxId);
 		$imageObject = (object)$imageObject->getData();
 
 		if (empty($imageObject->src)) {


### PR DESCRIPTION
This change will allow a user to get an Image Object with a specific lightbox ID set.
This function is allready included in the addImageToTemplate() function. The ID just gets passed through.