### PR TITLE
Prevent warnings when invalidating the cache

### DIFF
--- a/src/MadeYourDay/Contao/CustomElements.php
+++ b/src/MadeYourDay/Contao/CustomElements.php
@@ -1259,7 +1259,7 @@ class CustomElements
 
 			// Zend OPcache
 			if (function_exists('opcache_invalidate')) {
-				opcache_invalidate($path, true);
+				@opcache_invalidate($path, true);
 			}
 
 			// Zend Optimizer+


### PR DESCRIPTION
Easyname uses OPcache, but [restricts the opcache_invalidate() usage](https://www.easyname.at/de/support/hosting/183-warum-erhalte-ich-die-warnung-zend-opcache-api-is-restricted). 

Therefore Easyname Hosting the following warning in thrown:

    Warning: Zend OPcache API is restricted by "restrict_api" configuration directive in system/modules/rocksolid-custom-elements/src/MadeYourDay/Contao/CustomElements.php on line 1262
    #0 [internal function]: __error(2, 'Zend OPcache AP...', '/data/web/e2850...', 1262, Array)
    #1 system/modules/rocksolid-custom-elements/src/MadeYourDay/Contao/CustomElements.php(1262): opcache_invalidate('/data/web/e2850...', true)
    #2 system/modules/rocksolid-custom-elements/src/MadeYourDay/Contao/CustomElements.php(1237): MadeYourDay\Contao\CustomElements::refreshOpcodeCache('/data/web/e2850...')
    #3 system/modules/rocksolid-custom-elements/src/MadeYourDay/Contao/CustomElements.php(1247): MadeYourDay\Contao\CustomElements::loadConfig(true)
    #4 system/modules/rocksolid-custom-elements/src/MadeYourDay/Contao/CustomElements.php(54): MadeYourDay\Contao\CustomElements::reloadConfig()
    #5 system/modules/core/drivers/DC_Table.php(208): MadeYourDay\Contao\CustomElements->onloadCallback(Object(sioweb\contao\extensions\backend\DC_Table))
    #6 system/modules/SWBackend/drivers/DC_Table.php(40): Contao\DC_Table->__construct('tl_content', Array)
    #7 system/modules/SWBackend/classes/Backend.php(138): sioweb\contao\extensions\backend\DC_Table->__construct('tl_content', Array)
    #8 contao/main.php(142): Backend->getBackendModule('article')
    #9 contao/main.php(293): Main->run()
    #10 {main}
