### PR TITLE
Fix potential error if the config could not be loaded

### DIFF
--- a/src/CustomElements.php
+++ b/src/CustomElements.php
@@ -446,8 +446,8 @@ class CustomElements
 	{
         $config = static::getConfigByType($type);
 
-		if (!$config) {
-		    return;
+        if (!$config) {
+            return;
         }
 
 		$assetsDir = 'bundles/rocksolidcustomelements';
@@ -864,8 +864,8 @@ class CustomElements
 			$paletteFields = array();
             $config = static::getConfigByType($type);
 
-			if (!$config) {
-			    continue;
+            if (!$config) {
+                continue;
             }
 
 			$standardFields = is_array($config['standardFields']) ? $config['standardFields'] : array();

--- a/src/CustomElements.php
+++ b/src/CustomElements.php
@@ -444,6 +444,12 @@ class CustomElements
 	 */
 	protected function createDca($dc, $type, $createFromPost = false, $tmpField = null)
 	{
+        $config = static::getConfigByType($type);
+
+		if (!$config) {
+		    return;
+        }
+
 		$assetsDir = 'bundles/rocksolidcustomelements';
 
 		if (TL_MODE === 'BE') {
@@ -452,8 +458,6 @@ class CustomElements
 		}
 
 		$paletteFields = array();
-
-		$config = static::getConfigByType($type);
 		$standardFields = is_array($config['standardFields']) ? $config['standardFields'] : array();
 		$this->fieldsConfig = $config['fields'];
 
@@ -858,8 +862,12 @@ class CustomElements
 		foreach ($types as $type) {
 
 			$paletteFields = array();
+            $config = static::getConfigByType($type);
 
-			$config = static::getConfigByType($type);
+			if (!$config) {
+			    continue;
+            }
+
 			$standardFields = is_array($config['standardFields']) ? $config['standardFields'] : array();
 
 			foreach ($config['fields'] as $fieldName => $fieldConfig) {

--- a/src/CustomElements.php
+++ b/src/CustomElements.php
@@ -444,11 +444,11 @@ class CustomElements
 	 */
 	protected function createDca($dc, $type, $createFromPost = false, $tmpField = null)
 	{
-        $config = static::getConfigByType($type);
+		$config = static::getConfigByType($type);
 
-        if (!$config) {
-            return;
-        }
+		if (!$config) {
+			return;
+		}
 
 		$assetsDir = 'bundles/rocksolidcustomelements';
 
@@ -862,11 +862,11 @@ class CustomElements
 		foreach ($types as $type) {
 
 			$paletteFields = array();
-            $config = static::getConfigByType($type);
+			$config = static::getConfigByType($type);
 
-            if (!$config) {
-                continue;
-            }
+			if (!$config) {
+				continue;
+			}
 
 			$standardFields = is_array($config['standardFields']) ? $config['standardFields'] : array();
 


### PR DESCRIPTION
We have the below exception logged in the Sentry. Unfortunately I could not reproduce this myself. This likely happens when the config file cannot be loaded but I am not able to tell why.

```
ErrorException: Invalid argument supplied for foreach()
#17 vendor/madeyourday/contao-rocksolid-custom-elements/src/CustomElements.php(460): handleError
#16 vendor/madeyourday/contao-rocksolid-custom-elements/src/CustomElements.php(460): createDca
#15 vendor/madeyourday/contao-rocksolid-custom-elements/src/CustomElements.php(97): onloadCallback
#14 vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php(205): __construct
#13 vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php(407): getBackendModule
#12 vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php(135): run
#11 vendor/contao/core-bundle/src/Controller/BackendController.php(55): mainAction
#10 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(151): handleRaw
#9 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(68): handle
#8 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php(202): handle
#7 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php(462): forward
#6 vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php(57): forward
#5 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php(234): pass
#4 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php(251): invalidate
#3 vendor/friendsofsymfony/http-cache/src/SymfonyCache/EventDispatchingHttpCache.php(126): invalidate
#2 vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php(177): handle
#1 vendor/friendsofsymfony/http-cache/src/SymfonyCache/EventDispatchingHttpCache.php(98): handle
#0 web/app.php(30): null
```

Possibly related to #92.