### PR TITLE
Fixed compatibility with templates editor for Contao 4.9.2

### DIFF
--- a/src/Resources/contao/dca/tl_templates.php
+++ b/src/Resources/contao/dca/tl_templates.php
@@ -18,7 +18,7 @@ use Contao\CoreBundle\Util\PackageUtil;
 if (
 	is_callable([PackageUtil::class, 'getContaoVersion'])
 	&& version_compare(PackageUtil::getContaoVersion(), '4.7', '>=')
-    && version_compare(PackageUtil::getContaoVersion(), '4.9.2', '<')
+    	&& version_compare(PackageUtil::getContaoVersion(), '4.9.2', '<')
 ) {
 	$GLOBALS['TL_DCA']['tl_templates']['config']['validFileTypes'] .= ',php';
 	$GLOBALS['TL_DCA']['tl_templates']['config']['onload_callback'][] = function() {

--- a/src/Resources/contao/dca/tl_templates.php
+++ b/src/Resources/contao/dca/tl_templates.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\Util\PackageUtil;
 if (
 	is_callable([PackageUtil::class, 'getContaoVersion'])
 	&& version_compare(PackageUtil::getContaoVersion(), '4.7', '>=')
+    && version_compare(PackageUtil::getContaoVersion(), '4.9.2', '<')
 ) {
 	$GLOBALS['TL_DCA']['tl_templates']['config']['validFileTypes'] .= ',php';
 	$GLOBALS['TL_DCA']['tl_templates']['config']['onload_callback'][] = function() {

--- a/src/Resources/contao/dca/tl_templates.php
+++ b/src/Resources/contao/dca/tl_templates.php
@@ -18,10 +18,21 @@ use Contao\CoreBundle\Util\PackageUtil;
 if (
 	is_callable([PackageUtil::class, 'getContaoVersion'])
 	&& version_compare(PackageUtil::getContaoVersion(), '4.7', '>=')
-    	&& version_compare(PackageUtil::getContaoVersion(), '4.9.2', '<')
 ) {
-	$GLOBALS['TL_DCA']['tl_templates']['config']['validFileTypes'] .= ',php';
+	if (!empty($GLOBALS['TL_DCA']['tl_templates']['config']['validFileTypes'])) {
+		$GLOBALS['TL_DCA']['tl_templates']['config']['validFileTypes'] .= ',php';
+	}
 	$GLOBALS['TL_DCA']['tl_templates']['config']['onload_callback'][] = function() {
 		Config::set('editableFiles', Config::get('editableFiles') . ',php');
+	};
+	$originalButtonCallback = $GLOBALS['TL_DCA']['tl_templates']['list']['operations']['source']['button_callback'];
+	$GLOBALS['TL_DCA']['tl_templates']['list']['operations']['source']['button_callback'] = function($row, $href, $label, $title, $icon, $attributes) use ($originalButtonCallback) {
+		if (substr(basename($row['id']), 0, 5) !== 'rsce_' || substr($row['id'], -11) !== '_config.php') {
+			if (is_array($originalButtonCallback)) {
+				return System::importStatic($originalButtonCallback[0])->{$originalButtonCallback[1]}($row, $href, $label, $title, $icon, $attributes);
+			}
+			return $originalButtonCallback($row, $href, $label, $title, $icon, $attributes);
+		}
+		return '<a href="' . \Contao\Backend::addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . Contao\StringUtil::specialchars($title) . '"' . $attributes . '>' . Contao\Image::getHtml($icon, $label) . '</a> ';
 	};
 }


### PR DESCRIPTION
This should fix an issue with the new contao version 4.9.2 where templates can't be edited / not all file extensions are shown.

#118 