### PR TITLE
Set default for elementLabel to "%s"

### DIFF
--- a/src/CustomElements.php
+++ b/src/CustomElements.php
@@ -757,6 +757,8 @@ class CustomElements
 				// Don’t overwrite referenced variable
 				unset($fieldConfig['elementLabel']);
 				$fieldConfig['elementLabel'] = $translatedLabel;
+			} else {
+				$fieldConfig['elementLabel'] = "%s";
 			}
 
 			$fieldConfig['minItems'] = isset($fieldConfig['minItems']) ? (int)$fieldConfig['minItems'] : 0;


### PR DESCRIPTION
There is an issue where if `elementLabel` isn't set, the toolbar buttons are not clickable.
This change makes sure that `elementLabel` has at least the default value `"%s"`. Now each list element will have at least a number, this pushes the widget content down just enough so it doesn't cover the toolbar icons.

P.S. This is my first PR here, and I'm not primarily a PHP dev, so sorry if I didn't do this in a clean way.

Closes #143