### PR TITLE
Catch new doctrine exceptions

### DIFF
--- a/src/CustomElements.php
+++ b/src/CustomElements.php
@@ -1388,6 +1388,9 @@ class CustomElements
 		catch (DBALException $e) {
 			$themes = array();
 		}
+		catch (\Doctrine\DBAL\Exception $e) {
+			$themes = array();
+		}
 		$themeNamesByTemplateDir = array();
 		foreach ($themes as $theme) {
 			if ($theme['templates']) {


### PR DESCRIPTION
https://github.com/doctrine/dbal/blob/2.13.x/UPGRADE.md#deprecated-dbalexception

Alternatively, you could add `doctrine/dbal ^2.11 || ^3.0` to the composer.json and just catch the new exception. I used FQCN because its better to read than `Exception`.