### PR TITLE
Fix #167 bug with custom headline inputUnit field

### DIFF
--- a/src/Element/CustomElement.php
+++ b/src/Element/CustomElement.php
@@ -297,28 +297,30 @@ class CustomElement extends ContentElement
 		$this->Template->element_html_id ??= $this->Template->cssID[0] ?? null;
 		$this->Template->element_css_classes ??= $this->Template->cssID[1] ?? '';
 
-		// Legacy templates access the text using `$this->headline`, twig templates use `headline.text`
-		$this->Template->headline = new class($this->Template->headline, $this->Template->hl) implements \Stringable
-		{
-			public ?string $text;
-			public ?string $tag_name;
-
-			public function __construct(?string $text, ?string $tag_name)
+		if(!is_array($this->Template->headline)){
+			// Legacy templates access the text using `$this->headline`, twig templates use `headline.text`
+			$this->Template->headline = new class($this->Template->headline, $this->Template->hl) implements \Stringable
 			{
-				$this->text = $text;
-				$this->tag_name = $tag_name;
-			}
-
-			public function __toString(): string
-			{
-				return $this->text ?? '';
-			}
-
-			public function __invoke(): string
-			{
-				return $this->text ?? '';
-			}
-		};
+				public ?string $text;
+				public ?string $tag_name;
+	
+				public function __construct(?string $text, ?string $tag_name)
+				{
+					$this->text = $text;
+					$this->tag_name = $tag_name;
+				}
+	
+				public function __toString(): string
+				{
+					return $this->text ?? '';
+				}
+	
+				public function __invoke(): string
+				{
+					return $this->text ?? '';
+				}
+			};
+		}
 
 		// The parent::generate() method overwrites the template headline with $this->headline
 		// so we need to set it to the same callable object here

--- a/src/Element/CustomElement.php
+++ b/src/Element/CustomElement.php
@@ -297,30 +297,35 @@ class CustomElement extends ContentElement
 		$this->Template->element_html_id ??= $this->Template->cssID[0] ?? null;
 		$this->Template->element_css_classes ??= $this->Template->cssID[1] ?? '';
 
-		if(!is_array($this->Template->headline)){
-			// Legacy templates access the text using `$this->headline`, twig templates use `headline.text`
-			$this->Template->headline = new class($this->Template->headline, $this->Template->hl) implements \Stringable
-			{
-				public ?string $text;
-				public ?string $tag_name;
-	
-				public function __construct(?string $text, ?string $tag_name)
-				{
-					$this->text = $text;
-					$this->tag_name = $tag_name;
-				}
-	
-				public function __toString(): string
-				{
-					return $this->text ?? '';
-				}
-	
-				public function __invoke(): string
-				{
-					return $this->text ?? '';
-				}
-			};
+		if (
+			(!\is_string($this->Template->headline) && $this->Template->headline !== null)
+			|| (!\is_string($this->Template->hl) && $this->Template->hl !== null)
+		) {
+			return;
 		}
+
+		// Legacy templates access the text using `$this->headline`, twig templates use `headline.text`
+		$this->Template->headline = new class($this->Template->headline, $this->Template->hl) implements \Stringable
+		{
+			public ?string $text;
+			public ?string $tag_name;
+
+			public function __construct(?string $text, ?string $tag_name)
+			{
+				$this->text = $text;
+				$this->tag_name = $tag_name;
+			}
+
+			public function __toString(): string
+			{
+				return $this->text ?? '';
+			}
+
+			public function __invoke(): string
+			{
+				return $this->text ?? '';
+			}
+		};
 
 		// The parent::generate() method overwrites the template headline with $this->headline
 		// so we need to set it to the same callable object here


### PR DESCRIPTION
Fixes [#167](https://github.com/madeyourday/contao-rocksolid-custom-elements/issues/167)

```
TypeError:
Stringable@anonymous(): Argument #1 ($text) must be of type ?string, array given, called in /x/vendor/madeyourday/contao-rocksolid-custom-elements/src/Element/CustomElement.php on line 301

  at vendor/madeyourday/contao-rocksolid-custom-elements/src/Element/CustomElement.php:306
  at Stringable@anonymous/x/vendor/madeyourday/contao-rocksolid-custom-elements/src/Element/CustomElement.php:301$1->__construct()
     (vendor/madeyourday/contao-rocksolid-custom-elements/src/Element/CustomElement.php:301)
  at MadeYourDay\RockSolidCustomElements\Element\CustomElement->addFragmentControllerDefaults()
     (vendor/madeyourday/contao-rocksolid-custom-elements/src/Element/CustomElement.php:184)
  at MadeYourDay\RockSolidCustomElements\Element\CustomElement->compile()
     (vendor/contao/core-bundle/contao/elements/ContentElement.php:242)
  at Contao\ContentElement->generate()
     (vendor/madeyourday/contao-rocksolid-custom-elements/src/Element/CustomElement.php:51)
  at MadeYourDay\RockSolidCustomElements\Element\CustomElement->generate()
     (vendor/contao/core-bundle/contao/library/Contao/Controller.php:604)
  at Contao\Controller::getContentElement()
     (vendor/contao/core-bundle/contao/modules/ModuleArticle.php:191)
  at Contao\ModuleArticle->compile()
     (vendor/contao/core-bundle/contao/modules/Module.php:213)
  at Contao\Module->generate()
     (vendor/contao/core-bundle/contao/modules/ModuleArticle.php:69)
  at Contao\ModuleArticle->generate()
     (vendor/contao/core-bundle/contao/library/Contao/Controller.php:499)
  at Contao\Controller::getArticle()
     (vendor/contao/core-bundle/contao/library/Contao/Controller.php:364)
  at Contao\Controller::getFrontendModule()
     (vendor/contao/core-bundle/contao/pages/PageRegular.php:171)
  at Contao\PageRegular->prepare()
     (vendor/contao/core-bundle/contao/pages/PageRegular.php:46)
  at Contao\PageRegular->getResponse()
     (vendor/contao/core-bundle/contao/controllers/FrontendIndex.php:66)
  at Contao\FrontendIndex->renderPage()
     (vendor/symfony/http-kernel/HttpKernel.php:181)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:44)                
```