### PR TITLE
Correctly add element classes to new Twig template

### DIFF
--- a/src/Element/CustomElement.php
+++ b/src/Element/CustomElement.php
@@ -295,11 +295,7 @@ class CustomElement extends ContentElement
 		$this->Template->section ??= $this->strColumn;
 		$this->Template->properties ??= [];
 		$this->Template->element_html_id ??= $this->Template->cssID[0] ?? null;
-		$this->Template->element_css_classes ??= $this->Template->cssID[1] ?? '';
-
-		if (!empty($this->objModel->classes) && \is_array($this->objModel->classes)) {
-			$this->Template->element_css_classes .= ' ' . implode(' ', $this->objModel->classes);
-		}
+		$this->Template->element_css_classes ??= trim(($this->Template->cssID[1] ?? '') . ' ' . implode(' ', $this->objModel ? (array) $this->objModel->classes : []));
 
 		if (
 			(!\is_string($this->Template->headline) && $this->Template->headline !== null)

--- a/src/Element/CustomElement.php
+++ b/src/Element/CustomElement.php
@@ -297,6 +297,10 @@ class CustomElement extends ContentElement
 		$this->Template->element_html_id ??= $this->Template->cssID[0] ?? null;
 		$this->Template->element_css_classes ??= $this->Template->cssID[1] ?? '';
 
+		if (!empty($this->objModel->classes) && \is_array($this->objModel->classes)) {
+			$this->Template->element_css_classes .= ' ' . implode(' ', $this->objModel->classes);
+		}
+
 		if (
 			(!\is_string($this->Template->headline) && $this->Template->headline !== null)
 			|| (!\is_string($this->Template->hl) && $this->Template->hl !== null)


### PR DESCRIPTION
This complements https://github.com/contao/contao/pull/6975

I'm working on a new content element that uses nested fragments. It modifies the fragment references and adds a CSS class to each. If the nested element is a custom element, that class is lost in the Twig template. It is however "correctly" added to the legacy `$this->class` variable through the content element.

This sorta duplicates the code from https://github.com/contao/contao/blob/5.x/core-bundle/contao/elements/ContentElement.php#L260