### PR TITLE
Add support for backend jump targets in Contao 5.3

### DIFF
--- a/src/Widget/GroupStart.php
+++ b/src/Widget/GroupStart.php
@@ -8,6 +8,7 @@
 
 namespace MadeYourDay\RockSolidCustomElements\Widget;
 
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\System;
 use Contao\Widget;
 
@@ -47,16 +48,36 @@ class GroupStart extends Widget
 			$classes[] = 'collapsed';
 		}
 
-		return '</fieldset>'
-			. '<div class="clear"></div>'
-			. '<fieldset'
-			. ' id="pal_' . $this->strId . '"'
-			. ' class="' . implode(' ', $classes) . '"'
-			. '>'
-			. '<legend'
-			. ' onclick="AjaxRequest.toggleFieldset(this, &quot;' . $this->strId . '&quot;, &quot;' . $this->strTable . '&quot;)"'
-			. '>' . $this->strLabel
-			. '</legend>'
-			. ($this->description ? '<p class="rsce_group_description">' . $this->description . '</p>' : '');
+		if (version_compare(ContaoCoreBundle::getVersion(), '5.3', '>')) {
+			return '</fieldset>'
+				. '<div class="clear"></div>'
+				. '<fieldset'
+				. ' id="pal_' . $this->strId . '"'
+				. ' class="' . implode(' ', $classes) . '"'
+				. ' data-controller="contao--toggle-fieldset" data-contao--toggle-fieldset-id-value="pal_' . $this->strId . '"'
+				. ' data-contao--toggle-fieldset-table-value="' . $this->strTable . '"'
+				. ' data-contao--toggle-fieldset-collapsed-class="collapsed"'
+				. ' data-contao--jump-targets-target="section"'
+				. ' data-contao--jump-targets-label-value="' . $this->strLabel . '"'
+				. ' data-action="contao--jump-targets:scrollto->contao--toggle-fieldset#open"'
+				. '>'
+				. '<legend'
+				. ' data-action="click->contao--toggle-fieldset#toggle"'
+				. '>' . $this->strLabel
+				. '</legend>'
+				. ($this->description ? '<p class="rsce_group_description">' . $this->description . '</p>' : '');
+		} else {
+			return '</fieldset>'
+				. '<div class="clear"></div>'
+				. '<fieldset'
+				. ' id="pal_' . $this->strId . '"'
+				. ' class="' . implode(' ', $classes) . '"'
+				. '>'
+				. '<legend'
+				. ' onclick="AjaxRequest.toggleFieldset(this, &quot;' . $this->strId . '&quot;, &quot;' . $this->strTable . '&quot;)"'
+				. '>' . $this->strLabel
+				. '</legend>'
+				. ($this->description ? '<p class="rsce_group_description">' . $this->description . '</p>' : '');
+		}
 	}
 }

--- a/src/Widget/GroupStart.php
+++ b/src/Widget/GroupStart.php
@@ -48,7 +48,7 @@ class GroupStart extends Widget
 			$classes[] = 'collapsed';
 		}
 
-		if (version_compare(ContaoCoreBundle::getVersion(), '5.3', '>')) {
+		if (version_compare(ContaoCoreBundle::getVersion(), '5.3', '>=')) {
 			return '</fieldset>'
 				. '<div class="clear"></div>'
 				. '<fieldset'

--- a/src/Widget/ListStart.php
+++ b/src/Widget/ListStart.php
@@ -57,7 +57,7 @@ class ListStart extends Widget
 			'maxItems' => $this->maxItems,
 		);
 
-		if (version_compare(ContaoCoreBundle::getVersion(), '5.3', '>')) {
+		if (version_compare(ContaoCoreBundle::getVersion(), '5.3', '>=')) {
 			return '</fieldset>'
 				. '<div class="clear"></div>'
 				. '<fieldset'

--- a/src/Widget/ListStart.php
+++ b/src/Widget/ListStart.php
@@ -8,6 +8,7 @@
 
 namespace MadeYourDay\RockSolidCustomElements\Widget;
 
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\System;
 use Contao\Widget;
 
@@ -56,19 +57,42 @@ class ListStart extends Widget
 			'maxItems' => $this->maxItems,
 		);
 
-		return '</fieldset>'
-			. '<div class="clear"></div>'
-			. '<fieldset'
-			. ' id="pal_' . $this->strId . '"'
-			. ' class="' . implode(' ', $classes) . '"'
-			. ' data-config="' . htmlspecialchars(json_encode($config), ENT_QUOTES) . '"'
-			. $this->getAttributes()
-			. '>'
-			. '<legend'
-			. ' onclick="AjaxRequest.toggleFieldset(this, &quot;' . $this->strId . '&quot;, &quot;' . $this->strTable . '&quot;)"'
-			. '>' . $this->strLabel
-			. '</legend>'
-			. $toolbar
-			. ($this->description ? '<p class="rsce_list_description">' . $this->description . '</p>' : '');
+		if (version_compare(ContaoCoreBundle::getVersion(), '5.3', '>')) {
+			return '</fieldset>'
+				. '<div class="clear"></div>'
+				. '<fieldset'
+				. ' id="pal_' . $this->strId . '"'
+				. ' class="' . implode(' ', $classes) . '"'
+				. ' data-controller="contao--toggle-fieldset" data-contao--toggle-fieldset-id-value="pal_' . $this->strId . '"'
+				. ' data-contao--toggle-fieldset-table-value="' . $this->strTable . '"'
+				. ' data-contao--toggle-fieldset-collapsed-class="collapsed"'
+				. ' data-contao--jump-targets-target="section"'
+				. ' data-contao--jump-targets-label-value="' . $this->strLabel . '"'
+				. ' data-action="contao--jump-targets:scrollto->contao--toggle-fieldset#open"'
+				. ' data-config="' . htmlspecialchars(json_encode($config), ENT_QUOTES) . '"'
+				. $this->getAttributes()
+				. '>'
+				. '<legend'
+				. ' data-action="click->contao--toggle-fieldset#toggle"'
+				. '>' . $this->strLabel
+				. '</legend>'
+				. $toolbar
+				. ($this->description ? '<p class="rsce_list_description">' . $this->description . '</p>' : '');
+		} else {
+			return '</fieldset>'
+				. '<div class="clear"></div>'
+				. '<fieldset'
+				. ' id="pal_' . $this->strId . '"'
+				. ' class="' . implode(' ', $classes) . '"'
+				. ' data-config="' . htmlspecialchars(json_encode($config), ENT_QUOTES) . '"'
+				. $this->getAttributes()
+				. '>'
+				. '<legend'
+				. ' onclick="AjaxRequest.toggleFieldset(this, &quot;' . $this->strId . '&quot;, &quot;' . $this->strTable . '&quot;)"'
+				. '>' . $this->strLabel
+				. '</legend>'
+				. $toolbar
+				. ($this->description ? '<p class="rsce_list_description">' . $this->description . '</p>' : '');
+		}
 	}
 }


### PR DESCRIPTION
This PR adds support for the new backend jump targets and replaces the old onclick event for toggling the fieldsets in Contao 5.3 and higher.
<img width="445" alt="image" src="https://github.com/madeyourday/contao-rocksolid-custom-elements/assets/42083846/94e8cb5c-73af-492b-9b84-83c21e48f000">