### PR TITLE
Allow Group and ListItem fieldset legends to be keyboard focusable

### DIFF
--- a/src/Widget/GroupStart.php
+++ b/src/Widget/GroupStart.php
@@ -61,9 +61,12 @@ class GroupStart extends Widget
 				. ' data-contao--jump-targets-label-value="' . $this->strLabel . '"'
 				. ' data-action="contao--jump-targets:scrollto->contao--toggle-fieldset#open"'
 				. '>'
-				. '<legend'
+				. '<legend>'
+				. '<button'
+                . ' type="button"'
 				. ' data-action="click->contao--toggle-fieldset#toggle"'
 				. '>' . $this->strLabel
+                . '</button>'
 				. '</legend>'
 				. ($this->description ? '<p class="rsce_group_description">' . $this->description . '</p>' : '');
 		} else {

--- a/src/Widget/GroupStart.php
+++ b/src/Widget/GroupStart.php
@@ -63,10 +63,10 @@ class GroupStart extends Widget
 				. '>'
 				. '<legend>'
 				. '<button'
-                . ' type="button"'
+				. ' type="button"'
 				. ' data-action="click->contao--toggle-fieldset#toggle"'
 				. '>' . $this->strLabel
-                . '</button>'
+				. '</button>'
 				. '</legend>'
 				. ($this->description ? '<p class="rsce_group_description">' . $this->description . '</p>' : '');
 		} else {

--- a/src/Widget/ListStart.php
+++ b/src/Widget/ListStart.php
@@ -72,9 +72,12 @@ class ListStart extends Widget
 				. ' data-config="' . htmlspecialchars(json_encode($config), ENT_QUOTES) . '"'
 				. $this->getAttributes()
 				. '>'
-				. '<legend'
+				. '<legend>'
+                . '<button'
+                . ' type="button"'
 				. ' data-action="click->contao--toggle-fieldset#toggle"'
 				. '>' . $this->strLabel
+                . '</button>'
 				. '</legend>'
 				. $toolbar
 				. ($this->description ? '<p class="rsce_list_description">' . $this->description . '</p>' : '');

--- a/src/Widget/ListStart.php
+++ b/src/Widget/ListStart.php
@@ -73,11 +73,11 @@ class ListStart extends Widget
 				. $this->getAttributes()
 				. '>'
 				. '<legend>'
-                . '<button'
-                . ' type="button"'
+				. '<button'
+				. ' type="button"'
 				. ' data-action="click->contao--toggle-fieldset#toggle"'
 				. '>' . $this->strLabel
-                . '</button>'
+				. '</button>'
 				. '</legend>'
 				. $toolbar
 				. ($this->description ? '<p class="rsce_list_description">' . $this->description . '</p>' : '');


### PR DESCRIPTION
### Description

Been using keyboard navigation for a while now and this did grind my gears a little 😄.
This adjusts the fieldset legends to be the same as in Contao ^5.3 (this won't change anything pre Contao 5.3)