### PR TITLE
Adding a new keyword "extend" for the standardField function

### DIFF
--- a/src/CustomElements.php
+++ b/src/CustomElements.php
@@ -53,6 +53,11 @@ class CustomElements
 	protected $fieldsConfig = array();
 
 	/**
+	 * @var array Storage for original DCA fields
+	 */
+	protected $dcaFieldStorage = array();
+
+	/**
 	 * tl_content, tl_module and tl_form_field DCA onload callback
 	 *
 	 * Reloads config and creates the DCA fields
@@ -867,23 +872,34 @@ class CustomElements
 			}
 
 			if (isset($GLOBALS['TL_DCA'][$dc->table]['fields'][$extendName ?? $fieldName])) {
+				// Save a copy, so we alwayes have an unchanged state.
+				if (
+					!array_key_exists($dc->table, $this->dcaFieldStorage)
+					|| !array_key_exists(($extendName ?? $fieldName), $this->dcaFieldStorage[$dc->table])
+				) {
+					$this->dcaFieldStorage[$dc->table][$extendName ?? $fieldName]
+						= $GLOBALS['TL_DCA'][$dc->table]['fields'][$extendName ?? $fieldName];
+				}
+
+				$baseField = $this->dcaFieldStorage[$dc->table][$extendName ?? $fieldName];
 
 				if (
-					isset($GLOBALS['TL_DCA'][$dc->table]['fields'][$extendName ?? $fieldName]['eval'])
-					&& is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$extendName ?? $fieldName]['eval'])
+					isset($baseField['eval'])
+					&& is_array($baseField['eval'])
 					&& isset($fieldConfig['eval'])
 					&& is_array($fieldConfig['eval'])
 				) {
 					$fieldConfig['eval'] = array_merge(
-						$GLOBALS['TL_DCA'][$dc->table]['fields'][$extendName ?? $fieldName]['eval'],
+						$baseField['eval'],
 						$fieldConfig['eval']
 					);
 				}
 
 				unset($fieldConfig['inputType']);
 
+				// Don't use the $extendName here, 'cause this is the new/updated field.
 				$GLOBALS['TL_DCA'][$dc->table]['fields'][$fieldName] = array_merge(
-					$GLOBALS['TL_DCA'][$dc->table]['fields'][$extendName ?? $fieldName],
+					$baseField,
 					$fieldConfig
 				);
 


### PR DESCRIPTION
This PR enhances the functionality of `standardField.` It is now possible to use a field, such as "text", multiple times and implement it under different field names like "text", "text2", and "text3". This approach reduces the configuration required for an RSCE. Consequently, changes, for example to the TinyMCE editor, will apply to all text fields without needing to adjust each configuration individually.

Additionally, a cache has been implemented to save the original state of the fields before they are modified. This ensures that every "extend" operation uses the field's initial state, preventing previous modifications from overwriting the template.

Here is an example in which the **text** field is used three times.

The first field uses the simple `standardField`. This ensures that all existing RSCE configurations will continue to work. The **text2** field also extends the **text** field but overwrites it with a new label. The **text3** field, in turn, also uses the **text** field. It is clear from **text3** that it has not inherited any of the changes from **text2**, but rather uses the "standard" version of the field.

<img width="1919" height="1076" alt="image" src="https://github.com/user-attachments/assets/8fe42ad6-6347-4c2e-a057-b0cd6b02a151" />

