### PR TITLE
Fix compatibility with Hotwired Turbo in Contao 5.6

### DIFF
--- a/src/CustomElements.php
+++ b/src/CustomElements.php
@@ -644,7 +644,7 @@ class CustomElements
 			}
 		}
 
-        $GLOBALS['TL_DCA'][$dc->table]['fields']['rsce_data']['eval']['rsceScript'] = 'window.rsceInit(document.currentScript.closest(".tl_formbody_edit"));';
+		$GLOBALS['TL_DCA'][$dc->table]['fields']['rsce_data']['eval']['rsceScript'] = 'window.rsceInit(document.currentScript.closest(".tl_formbody_edit"));';
 
 		$paletteFields[] = 'rsce_data';
 

--- a/src/CustomElements.php
+++ b/src/CustomElements.php
@@ -644,7 +644,7 @@ class CustomElements
 			}
 		}
 
-		$GLOBALS['TL_DCA'][$dc->table]['fields']['rsce_data']['eval']['rsceScript'] = 'window.rsceInit([...document.querySelectorAll("script")].pop().closest(".tl_formbody_edit"));';
+        $GLOBALS['TL_DCA'][$dc->table]['fields']['rsce_data']['eval']['rsceScript'] = 'window.rsceInit(document.currentScript.closest(".tl_formbody_edit"));';
 
 		$paletteFields[] = 'rsce_data';
 

--- a/src/CustomElements.php
+++ b/src/CustomElements.php
@@ -630,13 +630,6 @@ class CustomElements
 			return;
 		}
 
-		$assetsDir = 'bundles/rocksolidcustomelements';
-
-		if (System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest(System::getContainer()->get('request_stack')->getCurrentRequest() ?? Request::create(''))) {
-			$GLOBALS['TL_JAVASCRIPT'][] = $assetsDir . '/js/be_main.js';
-			$GLOBALS['TL_CSS'][] = $assetsDir . '/css/be_main.css';
-		}
-
 		$paletteFields = array();
 		$standardFields = is_array($config['standardFields'] ?? null) ? $config['standardFields'] : array();
 		$this->fieldsConfig = $config['fields'];

--- a/src/EventListener/AddAssetsListener.php
+++ b/src/EventListener/AddAssetsListener.php
@@ -16,18 +16,18 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 class AddAssetsListener
 {
-    private ScopeMatcher $scopeMatcher;
+	private ScopeMatcher $scopeMatcher;
 
-    public function __construct(ScopeMatcher $scopeMatcher)
-    {
-        $this->scopeMatcher = $scopeMatcher;
-    }
+	public function __construct(ScopeMatcher $scopeMatcher)
+	{
+		$this->scopeMatcher = $scopeMatcher;
+	}
 
-    public function __invoke(RequestEvent $event): void
-    {
-        if ($this->scopeMatcher->isBackendMainRequest($event)) {
-            $GLOBALS['TL_JAVASCRIPT'][] = 'bundles/rocksolidcustomelements/js/be_main.js';
-            $GLOBALS['TL_CSS'][] = 'bundles/rocksolidcustomelements/css/be_main.css';
-        }
-    }
+	public function __invoke(RequestEvent $event): void
+	{
+		if ($this->scopeMatcher->isBackendMainRequest($event)) {
+			$GLOBALS['TL_JAVASCRIPT'][] = 'bundles/rocksolidcustomelements/js/be_main.js';
+			$GLOBALS['TL_CSS'][] = 'bundles/rocksolidcustomelements/css/be_main.css';
+		}
+	}
 }

--- a/src/EventListener/AddAssetsListener.php
+++ b/src/EventListener/AddAssetsListener.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright MADE/YOUR/DAY OG <mail@madeyourday.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MadeYourDay\RockSolidCustomElements\EventListener;
+
+use Contao\CoreBundle\Routing\ScopeMatcher;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+class AddAssetsListener
+{
+    private ScopeMatcher $scopeMatcher;
+
+    public function __construct(ScopeMatcher $scopeMatcher)
+    {
+        $this->scopeMatcher = $scopeMatcher;
+    }
+
+    public function __invoke(RequestEvent $event): void
+    {
+        if ($this->scopeMatcher->isBackendMainRequest($event)) {
+            $GLOBALS['TL_JAVASCRIPT'][] = 'bundles/rocksolidcustomelements/js/be_main.js';
+            $GLOBALS['TL_CSS'][] = 'bundles/rocksolidcustomelements/css/be_main.css';
+        }
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -5,3 +5,9 @@ services:
   MadeYourDay\RockSolidCustomElements\Migration\BasicEntitiesMigration:
     arguments:
       - '@database_connection'
+
+  MadeYourDay\RockSolidCustomElements\EventListener\AddAssetsListener:
+    arguments:
+      - '@contao.routing.scope_matcher'
+    tags:
+      - kernel.event_listener


### PR DESCRIPTION
### Description

I'll try to summarize what I found out since yesterday as there have been many reports about RSCE not working properly:

- DependsOn does not work, only works after a refresh
- Saving a RSCE with a list deletes everything (as in "invisible")

This can easily be reproduced by initially visiting the backend (a hard refresh is necessary to get rid of all JS :) ). After already having visited the element and going back, it will obviously work (as the JS has already been loaded)

1. Navigate to the RockSolidCustomElement that has a `list`
2. Update a list entry and save it
3. Poof, the list is empty.

After debugging a long time, I found out that the root cause is due to the JS not being loaded yet and parts of the JS not working, leading to `FORM_FIELDS[]` not being populated when sending the POST-Request. DC_Table will obviously get a `null` value and not save the contents of the list.

#### Fix the JavaScript working correctly

* See 63587ae6927bed44c940f8666e20c7bebcc98dcd

Loading the JS and CSS globally and there won't be a race condition as it already exists. This should also work with PHP 7.4 and Symfony < 6.


#### Update the init script

* See 98dbd0106f8cdbc481b143ff84a8ab2266618702

This was quite cumbersome to find as I didn't have the issue but I did ask if they did use some browser-plugins and in this case it has been something that does inject a `script` as the last element into the `<body>`:

The original JS would query all available scripts and then get the last one (this one actually assumes that the last script on the page is the init script for rsce but that's wrong in our case)

```js
window.rsceInit([...document.querySelectorAll("script")].pop().closest(".tl_formbody_edit"));
```

This is fixed by replacing it with the following as `document.currentScript` is basically the one you need
```js
window.rsceInit(document.currentScript.closest(".tl_formbody_edit"));
```


