### PR TITLE
Contao 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	},
 	"require":{
 		"php":">=7.4",
-		"contao/core-bundle":"^4.13 || ^5.0"
+		"contao/core-bundle":"^4.13 || ^5.0 || ^6.0"
 	},
 	"require-dev": {
 		"contao/manager-plugin": "^2.0"

--- a/src/DependencyInjection/RockSolidCustomElementsExtension.php
+++ b/src/DependencyInjection/RockSolidCustomElementsExtension.php
@@ -31,7 +31,7 @@ class RockSolidCustomElementsExtension extends Extension
 	/**
 	 * {@inheritdoc}
 	 */
-	public function load(array $configs, ContainerBuilder $container)
+	public function load(array $configs, ContainerBuilder $container): void
 	{
 		$loader = new YamlFileLoader(
 			$container,

--- a/src/Element/CustomElement.php
+++ b/src/Element/CustomElement.php
@@ -192,10 +192,6 @@ class CustomElement extends ContentElement
 	 */
 	protected function deserializeDataRecursive($data)
 	{
-		if (empty($data)) {
-			$data = array();
-		}
-
 		foreach ($data as $key => $value) {
 			if (is_string($value) && trim($value)) {
 				if (is_object($data)) {

--- a/src/Element/CustomElement.php
+++ b/src/Element/CustomElement.php
@@ -192,9 +192,9 @@ class CustomElement extends ContentElement
 	 */
 	protected function deserializeDataRecursive($data)
 	{
-        if (empty($data)) {
-            $data = array();
-        }
+		if (empty($data)) {
+			$data = array();
+		}
 
 		foreach ($data as $key => $value) {
 			if (is_string($value) && trim($value)) {

--- a/src/Element/CustomElement.php
+++ b/src/Element/CustomElement.php
@@ -192,6 +192,10 @@ class CustomElement extends ContentElement
 	 */
 	protected function deserializeDataRecursive($data)
 	{
+        if (empty($data)) {
+            $data = array();
+        }
+
 		foreach ($data as $key => $value) {
 			if (is_string($value) && trim($value)) {
 				if (is_object($data)) {

--- a/src/Resources/contao/templates/be_rsce_convert.html.twig
+++ b/src/Resources/contao/templates/be_rsce_convert.html.twig
@@ -1,0 +1,33 @@
+{% trans_default_domain 'contao_rocksolid_custom_elements' %}
+
+<div id="tl_maintenance_rsce_convert" class="maintenance_{{ isActive ? 'active' : 'inactive' }}">
+
+    <h2 class="sub_headline">{{ 'rocksolid_custom_elements.convert_headline'|trans }}</h2>
+
+    {% if isActive %}
+        {% if failedElements|default %}
+            <div class="tl_message">
+                {% for element in failedElements %}
+                    <p class="tl_error"><b>FAILED:</b> {{ element[0]|default ~ '-element, ID: ' ~ element[1]|default ~ ', Template: ' ~ element[2]|default }}</p>
+                {% endfor %}
+            </div>
+        {% endif %}
+        <div class="tl_message">
+            <p class="tl_confirm">{{ 'rocksolid_custom_elements.convert_success'|trans([elementsCount]) }}</p>
+        </div>
+    {% else %}
+        <form action="{{ action }}" class="tl_form" method="get" onsubmit="return window.confirm({{ 'rocksolid_custom_elements.convert_confirm'|trans|e('js') }})">
+            <div class="tl_formbody_edit">
+                <input type="hidden" name="act" value="rsce_convert">
+                <input type="hidden" name="do" value="maintenance">
+                <input type="hidden" name="rt" value="{{ contao.request_token }}">
+                <div class="tl_tbox">
+                    <p>{{ 'rocksolid_custom_elements.convert_description'|trans }}</p>
+                </div>
+            </div>
+            <div class="tl_submit_container">
+                <input type="submit" id="rsce_convert" class="tl_submit" value="{{ 'rocksolid_custom_elements.convert_submit'|trans }}">
+            </div>
+        </form>
+    {% endif %}
+</div>

--- a/src/Resources/contao/templates/be_rsce_convert.html.twig
+++ b/src/Resources/contao/templates/be_rsce_convert.html.twig
@@ -16,7 +16,7 @@
             <p class="tl_confirm">{{ 'rocksolid_custom_elements.convert_success'|trans([elementsCount]) }}</p>
         </div>
     {% else %}
-        <form action="{{ action }}" class="tl_form" method="get" onsubmit="return window.confirm({{ 'rocksolid_custom_elements.convert_confirm'|trans|e('js') }})">
+        <form action="{{ action }}" class="tl_form" method="get" onsubmit="return window.confirm('{{ 'rocksolid_custom_elements.convert_confirm'|trans|e('js') }}')">
             <div class="tl_formbody_edit">
                 <input type="hidden" name="act" value="rsce_convert">
                 <input type="hidden" name="do" value="maintenance">

--- a/src/Resources/contao/templates/be_rsce_data.html.twig
+++ b/src/Resources/contao/templates/be_rsce_data.html.twig
@@ -1,0 +1,5 @@
+{# closing the parent div element to make nested elements possible #}
+</div>{% if widgetGroup %}</div>{% endif %}
+{{ generate|raw }}
+{# starting a div element to keep the correct element structure #}
+{% if widgetGroup %}<div class="widget-group">{% endif %}<div style="display: none">

--- a/src/Resources/contao/templates/be_rsce_data.html5
+++ b/src/Resources/contao/templates/be_rsce_data.html5
@@ -1,5 +1,5 @@
 <?php /* closing the parent div element to make nested elements possible */ ?>
-</div><?php if (version_compare(Contao\CoreBundle\ContaoCoreBundle::getVersion(), '5.4', '>=')): ?></div><?php endif ?>
+</div><?php if ($this->widgetGroup): ?></div><?php endif ?>
 <?= $this->generate() ?>
 <?php /* starting a div element to keep the correct element structure */ ?>
-<?php if (version_compare(Contao\CoreBundle\ContaoCoreBundle::getVersion(), '5.4', '>=')): ?><div class="widget-group"><?php endif ?><div style="display: none">
+<?php if ($this->widgetGroup): ?><div class="widget-group"><?php endif ?><div style="display: none">

--- a/src/Resources/contao/templates/be_rsce_group.html.twig
+++ b/src/Resources/contao/templates/be_rsce_group.html.twig
@@ -1,0 +1,5 @@
+{# closing the parent div element to make nested elements possible #}
+</div>{% if widgetGroup %}</div>{% endif %}
+{{ generate|raw }}
+{# starting a div element to keep the correct element structure #}
+{% if widgetGroup %}<div class="widget-group">{% endif %}<div style="display: none">

--- a/src/Resources/contao/templates/be_rsce_group.html5
+++ b/src/Resources/contao/templates/be_rsce_group.html5
@@ -1,5 +1,5 @@
 <?php /* closing the parent div element to make nested elements possible */ ?>
-</div><?php if (version_compare(Contao\CoreBundle\ContaoCoreBundle::getVersion(), '5.4', '>=')): ?></div><?php endif ?>
+</div><?php if ($this->widgetGroup): ?></div><?php endif ?>
 <?= $this->generate() ?>
 <?php /* starting a div element to keep the correct element structure */ ?>
-<?php if (version_compare(Contao\CoreBundle\ContaoCoreBundle::getVersion(), '5.4', '>=')): ?><div class="widget-group"><?php endif ?><div style="display: none">
+<?php if ($this->widgetGroup): ?><div class="widget-group"><?php endif ?><div style="display: none">

--- a/src/Resources/contao/templates/be_rsce_list.html.twig
+++ b/src/Resources/contao/templates/be_rsce_list.html.twig
@@ -1,0 +1,5 @@
+{# closing the parent div element to make nested elements possible #}
+</div>{% if widgetGroup %}</div>{% endif %}
+{{ generate|raw }}
+{# starting a div element to keep the correct element structure #}
+{% if widgetGroup %}<div class="widget-group">{% endif %}<div style="display: none">

--- a/src/Resources/contao/templates/be_rsce_list.html5
+++ b/src/Resources/contao/templates/be_rsce_list.html5
@@ -1,5 +1,5 @@
 <?php /* closing the parent div element to make nested elements possible */ ?>
-</div><?php if (version_compare(Contao\CoreBundle\ContaoCoreBundle::getVersion(), '5.4', '>=')): ?></div><?php endif ?>
+</div><?php if ($this->widgetGroup): ?></div><?php endif ?>
 <?= $this->generate() ?>
 <?php /* starting a div element to keep the correct element structure */ ?>
-<?php if (version_compare(Contao\CoreBundle\ContaoCoreBundle::getVersion(), '5.4', '>=')): ?><div class="widget-group"><?php endif ?><div style="display: none">
+<?php if ($this->widgetGroup): ?><div class="widget-group"><?php endif ?><div style="display: none">

--- a/src/Resources/contao/templates/form_rsce_plain.html.twig
+++ b/src/Resources/contao/templates/form_rsce_plain.html.twig
@@ -1,0 +1,1 @@
+{{ generateWithError.invoke(true)|raw }}

--- a/src/Resources/contao/templates/form_rsce_plain.html.twig
+++ b/src/Resources/contao/templates/form_rsce_plain.html.twig
@@ -1,1 +1,1 @@
-{{ generateWithError.invoke(true)|raw }}
+{{ generate|raw }}

--- a/src/Template/CustomTemplate.php
+++ b/src/Template/CustomTemplate.php
@@ -88,6 +88,11 @@ class CustomTemplate extends FrontendTemplate
 			return $templates;
 		}
 
+		if (!method_exists(parent::class, 'getTemplate')) {
+            return array();
+		}
+
+
 		return array(parent::getTemplate($template, $format));
 	}
 

--- a/src/Template/CustomTemplate.php
+++ b/src/Template/CustomTemplate.php
@@ -89,7 +89,7 @@ class CustomTemplate extends FrontendTemplate
 		}
 
 		if (!method_exists(parent::class, 'getTemplate')) {
-            return array();
+			return array();
 		}
 
 		return array(parent::getTemplate($template, $format));

--- a/src/Template/CustomTemplate.php
+++ b/src/Template/CustomTemplate.php
@@ -92,7 +92,6 @@ class CustomTemplate extends FrontendTemplate
             return array();
 		}
 
-
 		return array(parent::getTemplate($template, $format));
 	}
 

--- a/src/Widget/Data.php
+++ b/src/Widget/Data.php
@@ -23,22 +23,22 @@ class Data extends Widget
 	 */
 	protected $blnSubmitInput = true;
 
-    /**
-     * @var boolean Widget group wrapper
-     */
-    protected $widgetGroup = false;
+	/**
+	 * @var boolean Widget group wrapper
+	 */
+	protected $widgetGroup = false;
 
 	/**
 	 * @var string Template
 	 */
 	protected $strTemplate = 'be_rsce_data';
 
-    public function __construct($arrAttributes = null)
-    {
-        parent::__construct($arrAttributes);
+	public function __construct($arrAttributes = null)
+	{
+		parent::__construct($arrAttributes);
 
-        $this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
-    }
+		$this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
+	}
 
 	/**
 	 * Generate the widget and return it as string

--- a/src/Widget/Data.php
+++ b/src/Widget/Data.php
@@ -8,6 +8,7 @@
 
 namespace MadeYourDay\RockSolidCustomElements\Widget;
 
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\Widget;
 
 /**
@@ -22,10 +23,22 @@ class Data extends Widget
 	 */
 	protected $blnSubmitInput = true;
 
+    /**
+     * @var boolean Widget group wrapper
+     */
+    protected $widgetGroup = false;
+
 	/**
 	 * @var string Template
 	 */
 	protected $strTemplate = 'be_rsce_data';
+
+    public function __construct($arrAttributes = null)
+    {
+        parent::__construct($arrAttributes);
+
+        $this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
+    }
 
 	/**
 	 * Generate the widget and return it as string

--- a/src/Widget/GroupStart.php
+++ b/src/Widget/GroupStart.php
@@ -24,22 +24,22 @@ class GroupStart extends Widget
 	 */
 	protected $blnSubmitInput = false;
 
-    /**
-     * @var boolean Widget group wrapper
-     */
-    protected $widgetGroup = false;
+	/**
+	 * @var boolean Widget group wrapper
+	 */
+	protected $widgetGroup = false;
 
 	/**
 	 * @var string Template
 	 */
 	protected $strTemplate = 'be_rsce_group';
 
-    public function __construct($arrAttributes = null)
-    {
-        parent::__construct($arrAttributes);
+	public function __construct($arrAttributes = null)
+	{
+		parent::__construct($arrAttributes);
 
-        $this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
-    }
+		$this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
+	}
 
 	/**
 	 * Generate the widget and return it as string

--- a/src/Widget/GroupStart.php
+++ b/src/Widget/GroupStart.php
@@ -24,10 +24,22 @@ class GroupStart extends Widget
 	 */
 	protected $blnSubmitInput = false;
 
+    /**
+     * @var boolean Widget group wrapper
+     */
+    protected $widgetGroup = false;
+
 	/**
 	 * @var string Template
 	 */
 	protected $strTemplate = 'be_rsce_group';
+
+    public function __construct($arrAttributes = null)
+    {
+        parent::__construct($arrAttributes);
+
+        $this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
+    }
 
 	/**
 	 * Generate the widget and return it as string

--- a/src/Widget/ListItemStart.php
+++ b/src/Widget/ListItemStart.php
@@ -8,6 +8,7 @@
 
 namespace MadeYourDay\RockSolidCustomElements\Widget;
 
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\Image;
 use Contao\Widget;
 
@@ -23,10 +24,22 @@ class ListItemStart extends Widget
 	 */
 	protected $blnSubmitInput = false;
 
+    /**
+     * @var boolean Widget group wrapper
+     */
+    protected $widgetGroup = false;
+
 	/**
 	 * @var string Template
 	 */
 	protected $strTemplate = 'be_rsce_list';
+
+    public function __construct($arrAttributes = null)
+    {
+        parent::__construct($arrAttributes);
+
+        $this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
+    }
 
 	/**
 	 * Generate the widget and return it as string

--- a/src/Widget/ListItemStart.php
+++ b/src/Widget/ListItemStart.php
@@ -24,22 +24,22 @@ class ListItemStart extends Widget
 	 */
 	protected $blnSubmitInput = false;
 
-    /**
-     * @var boolean Widget group wrapper
-     */
-    protected $widgetGroup = false;
+	/**
+	 * @var boolean Widget group wrapper
+	 */
+	protected $widgetGroup = false;
 
 	/**
 	 * @var string Template
 	 */
 	protected $strTemplate = 'be_rsce_list';
 
-    public function __construct($arrAttributes = null)
-    {
-        parent::__construct($arrAttributes);
+	public function __construct($arrAttributes = null)
+	{
+		parent::__construct($arrAttributes);
 
-        $this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
-    }
+		$this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
+	}
 
 	/**
 	 * Generate the widget and return it as string

--- a/src/Widget/ListItemStop.php
+++ b/src/Widget/ListItemStop.php
@@ -8,6 +8,7 @@
 
 namespace MadeYourDay\RockSolidCustomElements\Widget;
 
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\Widget;
 
 /**
@@ -22,10 +23,22 @@ class ListItemStop extends Widget
 	 */
 	protected $blnSubmitInput = false;
 
+    /**
+     * @var boolean Widget group wrapper
+     */
+    protected $widgetGroup = false;
+
 	/**
 	 * @var string Template
 	 */
 	protected $strTemplate = 'be_rsce_list';
+
+    public function __construct($arrAttributes = null)
+    {
+        parent::__construct($arrAttributes);
+
+        $this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
+    }
 
 	/**
 	 * Generate the widget and return it as string

--- a/src/Widget/ListItemStop.php
+++ b/src/Widget/ListItemStop.php
@@ -23,22 +23,22 @@ class ListItemStop extends Widget
 	 */
 	protected $blnSubmitInput = false;
 
-    /**
-     * @var boolean Widget group wrapper
-     */
-    protected $widgetGroup = false;
+	/**
+	 * @var boolean Widget group wrapper
+	 */
+	protected $widgetGroup = false;
 
 	/**
 	 * @var string Template
 	 */
 	protected $strTemplate = 'be_rsce_list';
 
-    public function __construct($arrAttributes = null)
-    {
-        parent::__construct($arrAttributes);
+	public function __construct($arrAttributes = null)
+	{
+		parent::__construct($arrAttributes);
 
-        $this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
-    }
+		$this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
+	}
 
 	/**
 	 * Generate the widget and return it as string

--- a/src/Widget/ListStart.php
+++ b/src/Widget/ListStart.php
@@ -24,22 +24,22 @@ class ListStart extends Widget
 	 */
 	protected $blnSubmitInput = false;
 
-    /**
-     * @var boolean Widget group wrapper
-     */
-    protected $widgetGroup = false;
+	/**
+	 * @var boolean Widget group wrapper
+	 */
+	protected $widgetGroup = false;
 
 	/**
 	 * @var string Template
 	 */
 	protected $strTemplate = 'be_rsce_list';
 
-    public function __construct($arrAttributes = null)
-    {
-        parent::__construct($arrAttributes);
+	public function __construct($arrAttributes = null)
+	{
+		parent::__construct($arrAttributes);
 
-        $this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
-    }
+		$this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
+	}
 
 	/**
 	 * Generate the widget and return it as string

--- a/src/Widget/ListStart.php
+++ b/src/Widget/ListStart.php
@@ -24,10 +24,22 @@ class ListStart extends Widget
 	 */
 	protected $blnSubmitInput = false;
 
+    /**
+     * @var boolean Widget group wrapper
+     */
+    protected $widgetGroup = false;
+
 	/**
 	 * @var string Template
 	 */
 	protected $strTemplate = 'be_rsce_list';
+
+    public function __construct($arrAttributes = null)
+    {
+        parent::__construct($arrAttributes);
+
+        $this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
+    }
 
 	/**
 	 * Generate the widget and return it as string

--- a/src/Widget/ListStop.php
+++ b/src/Widget/ListStop.php
@@ -23,22 +23,22 @@ class ListStop extends Widget
 	 */
 	protected $blnSubmitInput = false;
 
-    /**
-     * @var boolean Widget group wrapper
-     */
-    protected $widgetGroup = false;
+	/**
+	 * @var boolean Widget group wrapper
+	 */
+	protected $widgetGroup = false;
 
 	/**
 	 * @var string Template
 	 */
 	protected $strTemplate = 'be_rsce_list';
 
-    public function __construct($arrAttributes = null)
-    {
-        parent::__construct($arrAttributes);
+	public function __construct($arrAttributes = null)
+	{
+		parent::__construct($arrAttributes);
 
-        $this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
-    }
+		$this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
+	}
 
 	/**
 	 * Generate the widget and return it as string

--- a/src/Widget/ListStop.php
+++ b/src/Widget/ListStop.php
@@ -8,6 +8,7 @@
 
 namespace MadeYourDay\RockSolidCustomElements\Widget;
 
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\Widget;
 
 /**
@@ -22,10 +23,22 @@ class ListStop extends Widget
 	 */
 	protected $blnSubmitInput = false;
 
+    /**
+     * @var boolean Widget group wrapper
+     */
+    protected $widgetGroup = false;
+
 	/**
 	 * @var string Template
 	 */
 	protected $strTemplate = 'be_rsce_list';
+
+    public function __construct($arrAttributes = null)
+    {
+        parent::__construct($arrAttributes);
+
+        $this->widgetGroup = version_compare(ContaoCoreBundle::getVersion(), '5.4', '>=');
+    }
 
 	/**
 	 * Generate the widget and return it as string


### PR DESCRIPTION
### Description

- Adds Contao 6 compatibility

I kept the PR small so changes are clear

- 5bedf9fc476027d7b6fec60698df178ff1049a09 fixes a PHP 8.5 warning
- return type `void` is needed for Sf8 compatibility 6b76da612535be47485eac9b5b55bf3e976ac41b
- using `method_exists` for checking if `getTemplate` exists here: c2963b931c13104e544acafc442837e2a4c75546
   - Wondering if we still need to do check for the twig templates
- I extracted the version check for the widget_group to the widgets 88c4d7fc77c8375902fb0135cb7720668f0b955a
- Provided twig templates 383a8b9a2a1236e665e7314a892324fe5779694a