### PR TITLE
Fix loading the group and list fieldset states

### DIFF
--- a/src/Widget/GroupStart.php
+++ b/src/Widget/GroupStart.php
@@ -53,9 +53,11 @@ class GroupStart extends Widget
 		$classes = [$this->arrConfiguration['tl_class'] ?? '', 'tl_box', 'rsce_group'];
 		$fs = System::getContainer()->get('request_stack')->getSession()->getBag('contao_backend')->get('fieldset_states');
 
+		$fieldsetId = 'pal_' . $this->strId;
+
 		if (
-			(isset($fs[$this->strTable][$this->strId]) && !$fs[$this->strTable][$this->strId])
-			|| (!isset($fs[$this->strTable][$this->strId]) && !empty($this->arrConfiguration['collapsed']))
+			(isset($fs[$this->strTable][$fieldsetId]) && !$fs[$this->strTable][$fieldsetId])
+			|| (!isset($fs[$this->strTable][$fieldsetId]) && !empty($this->arrConfiguration['collapsed']))
 		) {
 			$classes[] = 'collapsed';
 		}

--- a/src/Widget/ListStart.php
+++ b/src/Widget/ListStart.php
@@ -57,9 +57,11 @@ class ListStart extends Widget
 		$classes = [$this->arrConfiguration['tl_class'] ?? '', 'tl_box', 'rsce_list'];
 		$fs = System::getContainer()->get('request_stack')->getSession()->getBag('contao_backend')->get('fieldset_states');
 
+		$fieldsetId = 'pal_' . $this->strId;
+
 		if (
-			(isset($fs[$this->strTable][$this->strId]) && !$fs[$this->strTable][$this->strId])
-			|| (!isset($fs[$this->strTable][$this->strId]) && !empty($this->arrConfiguration['collapsed']))
+			(isset($fs[$this->strTable][$fieldsetId]) && !$fs[$this->strTable][$fieldsetId])
+			|| (!isset($fs[$this->strTable][$fieldsetId]) && !empty($this->arrConfiguration['collapsed']))
 		) {
 			$classes[] = 'collapsed';
 		}


### PR DESCRIPTION
### Description

Fixes an issue with fieldset states (collapsed, not collapsed) not loading. Whilst saving did work, those were saved with the `pal_` prefix.

```
array:10 [▼
  "tl_layout" => array:1 [▶]
  "tl_article" => array:3 [▶]
  "tl_content" => array:10 [▼
    "template_legend" => 0
    "expert_legend" => 0
    "protected_legend" => 0
    "poster_legend" => 0
    "pal_rsce_field_list_rsce_list_start" => 0
    "pal_rsce_field_grid" => 1
    "layout_legend" => 1
    "text_legend" => 1
    "pal_rsce_field_media" => 0
    "pal_rsce_field_settings" => 0
  ]
```

Unsure when it broke but it also doesn't work in Contao 5.7
May have been broken since switching from C4 to C5 🤔 